### PR TITLE
base_helper template is missing rst.css

### DIFF
--- a/templates/base_helper.tmpl
+++ b/templates/base_helper.tmpl
@@ -80,6 +80,7 @@ lang="${lang}">
     %if use_bundles:
         <link href="/assets/css/all.css" rel="stylesheet" type="text/css">
     %else:
+        <link href="/assets/css/rst.css" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="/assets/css/foundation.min.css" />
         <link rel="stylesheet" href="/assets/css/app.css" />
         %if has_custom_css:


### PR DESCRIPTION
Add missing rst.css to base_helper template which is required for rst extensions to be properly rendered.
