### PR TITLE
Add foundation6.theme meta file

### DIFF
--- a/foundation6.theme
+++ b/foundation6.theme
@@ -1,0 +1,7 @@
+[Theme]
+engine = mako
+parent = base
+author = Niko Wenselowski
+author_url = https://github.com/okin
+based_on = ZURB Foundation <http://foundation.zurb.com/>
+license = AGPLv3


### PR DESCRIPTION
Hi there,
this PR adds a .theme meta file, for the use of Nikola and the new themes.getnikola.com site.

On a side note, could we please take the theme and put it in the `getnikola/nikola-themes` repo, instead of using a submodule? It would make maintenance easier for us.